### PR TITLE
Prepare documentation for rendering in Hugo

### DIFF
--- a/docs/adapter-code_aster.md
+++ b/docs/adapter-code_aster.md
@@ -2,8 +2,6 @@
 title: The code_aster adapter
 permalink: adapter-code_aster.html
 url: /adapter-code_aster.html
-aliases:
-  - /docs/adapters/code_aster/
 keywords: CHT, pyprecice
 summary: "On this page, we give a step-by-step guide how to get and install code_aster and the code_aster adapter. The adapter currently supports usage of code_aster as solid solver for conjugate heat transfer problems. We use the Python command files of code_aster and call the preCICE Python bindings from there."
 ---

--- a/docs/adapter-code_aster.md
+++ b/docs/adapter-code_aster.md
@@ -1,6 +1,9 @@
 ---
 title: The code_aster adapter
 permalink: adapter-code_aster.html
+url: /adapter-code_aster.html
+aliases:
+  - /docs/adapters/code_aster/
 keywords: CHT, pyprecice
 summary: "On this page, we give a step-by-step guide how to get and install code_aster and the code_aster adapter. The adapter currently supports usage of code_aster as solid solver for conjugate heat transfer problems. We use the Python command files of code_aster and call the preCICE Python bindings from there."
 ---


### PR DESCRIPTION
Preserve the existing code_aster documentation URL in Hugo while redirecting the new section path through an alias.