### PR TITLE
Prepare documentation for rendering in Hugo(native)

### DIFF
--- a/docs/adapter-code_aster.md
+++ b/docs/adapter-code_aster.md
@@ -1,7 +1,8 @@
 ---
 title: The code_aster adapter
 permalink: adapter-code_aster.html
-url: /adapter-code_aster.html
+aliases:
+  - /adapter-code_aster.html
 keywords: CHT, pyprecice
 summary: "On this page, we give a step-by-step guide how to get and install code_aster and the code_aster adapter. The adapter currently supports usage of code_aster as solid solver for conjugate heat transfer problems. We use the Python command files of code_aster and call the preCICE Python bindings from there."
 ---


### PR DESCRIPTION
Preserve the existing code_aster-adapter documentation URL for the Hugo migration (native)